### PR TITLE
let Lucy react to recurring events

### DIFF
--- a/app/service/google/GoogleCalendarApi.js
+++ b/app/service/google/GoogleCalendarApi.js
@@ -6,7 +6,7 @@ let logger = app.logger;
 module.exports = class GoogleCalendarApi {
 	static getNextShow() {
 		return new Promise(function(resolve, reject) {
-			axios.get('https://www.googleapis.com/calendar/v3/calendars/' + app.config.google.calendarId + '/events?timeMin=' + moment().add(15, 'minutes').toISOString() + '&key=' + app.config.google.apiKey)
+			axios.get('https://www.googleapis.com/calendar/v3/calendars/' + app.config.google.calendarId + '/events?orderBy=startTime&maxResults=5&singleEvents=true&timeMin=' + moment().add(15, 'minutes').toISOString() + '&key=' + app.config.google.apiKey)
 				.then((response) => {
 					var nextShow;
 					let shows = response.data.items;


### PR DESCRIPTION
using the singleEvents parameter in the API call has Google Calendar respond with every recurring event as a single event each (instead of only the first event)

orderBy startTime causes the API to sort events by their starting time (this might make the sort function obsolete, don't really know)

setting maxResults to 5 so that Google doesn't respond with hundreds of items

(https://developers.google.com/calendar/v3/reference/events/list)