### PR TITLE
link to tweet when posting new tweets -- closes #16

### DIFF
--- a/app/listener/twitter/timeline/TwitterTimelinePostsListener.js
+++ b/app/listener/twitter/timeline/TwitterTimelinePostsListener.js
@@ -59,7 +59,7 @@ module.exports = class TwitterTimelinePostsListener {
 							value: '@' + tweet.user.screen_name
 						}
 					],
-					url: tweet.user.url
+					url: 'https://twitter.com/' + tweet.user.screen_name + '/status/' + tweet.id_str
 				}
 			})
 			.then((message) => {


### PR DESCRIPTION
Quite a simple change, to be honest.

From my testing, ``tweet.entities.urls`` was always just an empty array, so I suggest using this instead. Of course, there is the possibility of this being broken by Twitter at some point, but I don't think that's likely. As of now, links generated by this method are correct.